### PR TITLE
Added checkbox "Loop through prompts (if fewer prompts than models)".…

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -31,7 +31,7 @@ body:
   - type: dropdown
     id: webui
     attributes:
-    multiple: true
+      multiple: true
       label: Which WebUI
       description: What WebUI do you use?
       options:
@@ -43,7 +43,7 @@ body:
   - type: dropdown
     id: webui-version
     attributes:
-    multiple: true
+      multiple: true
       label: WebUI version
       description: Which WebUI version do you use?
       options:

--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -1,0 +1,103 @@
+name: Bug Report
+description: File a bug report
+title: "[Bug]: "
+labels: ["bug", "triage"]
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report!
+
+  - type: checkboxes
+    id: otherIssues
+    attributes:
+      label: Please search to see if an issue already exists for the bug you encountered, and that it hasn't been fixed in a recent build/commit.
+      options:
+        - label: I have searched the existing issues
+          required: true
+
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: Also tell us, what did you expect to happen?
+      placeholder: Tell us what you see!
+      value: "A bug happened!"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: webui
+    attributes:
+    multiple: true
+      label: Which WebUI
+      description: What WebUI do you use?
+      options:
+        - AUTOMATIC1111 (Default)
+        - Vladmandic (not tested)
+    validations:
+      required: true
+
+  - type: dropdown
+    id: webui-version
+    attributes:
+    multiple: true
+      label: WebUI version
+      description: Which WebUI version do you use?
+      options:
+        - 1.4.*
+        - 1.3.*
+        - 1.2.*
+        - 1.1.*
+    validations:
+      required: true
+
+  - type: dropdown
+    id: browsers
+    attributes:
+      label: What browsers are you seeing the problem on?
+      multiple: true
+      options:
+        - Firefox
+        - Chrome
+        - Safari
+        - Microsoft Edge
+
+  - type: dropdown
+    id: py-version
+    attributes:
+      label: What Python version are you running on?
+      multiple: false
+      options:
+        - Python 3.10.x
+        - Python 3.11.x (above, no supported yet)
+        - Python 3.9.x (below, no recommended)
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce the problem
+      description: Please provide us with precise step by step information on how to reproduce the bug
+      value: |
+        1. Go to .... 
+        2. Press ....
+        3. ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: extensions
+    attributes:
+      label: List of extensions
+      description: Are you using any extensions other than built-ins and this one? If yes, provide a list, you can copy it at "Extensions" tab. Write "No" otherwise.
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant log output
+      description: Please provide **full** cmd/terminal logs from the moment you started UI to the end of it, after your bug happened. If it's very long, provide a link to pastebin or similar service. This will be automatically formatted into code, so no need for backticks.
+      render: shell

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,42 @@
+name: Feature request
+description: Request a new feature
+title: "[Feature Request]: "
+labels: ["enhancement"]
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this feature request!
+
+  - type: checkboxes
+    id: otherIssues
+    attributes:
+      label: Please search to see if an issue already exists for the feature you want, and that it hasn't been fixed in a recent build/commit.
+      options:
+        - label: I have searched the existing issues
+          required: true
+
+  - type: textarea
+    id: what-should-happen
+    attributes:
+      label: What would this feature do?
+      description: Also tell us, what your feature idea would do?
+    validations:
+      required: true
+
+  - type: textarea
+    id: workflow
+    attributes:
+      label: What is the workflow for your feature idea?
+      description: Tell us how your feature idea would work. What Syntax would you use (if applicable)?
+    validations:
+      required: true
+
+  - type: textarea
+    id: other-info
+    attributes:
+      label: Any other information?
+      description: Any other information you want to add?
+    validations:
+      required: false

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@ Forked from: https://github.com/h43lb1t0/SD-WebUI-BatchCheckpointPrompt
 
 So far I've just added in a check box to let you put in one prompt and have it apply (or a shorter list of prompts than models and it will loop the prompt list)
 
+ORIGNAL README:
+
 # batch Checkpoints with Prompt
 a script for [AUTOMATIC1111](https://github.com/AUTOMATIC1111/stable-diffusion-webui)
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+Forked from: https://github.com/h43lb1t0/SD-WebUI-BatchCheckpointPrompt
+
+So far I've just added in a check box to let you put in one prompt and have it apply (or a shorter list of prompts than models and it will loop the prompt list)
+
 # batch Checkpoints with Prompt
 a script for [AUTOMATIC1111](https://github.com/AUTOMATIC1111/stable-diffusion-webui)
 


### PR DESCRIPTION
Added checkbox "Loop through prompts (if fewer prompts than models). If unchecked, model and prompt list must be the same length.

The base behavior is identical, but if this box is checked, it will just loop through the one or more prompts as needed to satisfy the prompt list and run the generations.  This will let me just enter one prompt and test it against a bunch of models.

An interesting idea could be an iterator tag like [i=1++] that the code would recognize and increment in the loop (as in if you have a bunch of lora training checkpoints to compare).  I might do that soon, as that's something I want to automate. Easy way to quickly find out when a lora is overtrained without having to manually run a bazillion generations manually...