### PR TITLE
Repeat prompt(s) and prompt-embedded iterator tags options

### DIFF
--- a/scripts/BatchParams.py
+++ b/scripts/BatchParams.py
@@ -6,6 +6,8 @@ import os
 from scripts.Logger import Logger
 from scripts.Utils import Utils
 
+import itertools
+
 import modules
 import modules.shared as shared
 
@@ -25,30 +27,21 @@ class BatchParams:
                f"batch_count: {self.batch_count},\n "
                f"clip_skip: {self.clip_skip}\n")
 
-logger = Logger()
 
-def get_all_batch_params(p: Union[modules.processing.StableDiffusionProcessingTxt2Img, modules.processing.StableDiffusionProcessingImg2Img], checkpoints_as_string: str, prompts_as_string: str) -> List[BatchParams]:
-        
-        def getRegexFromOpts(key: str) -> Tuple[str]:
-            sub_pattern = getattr(shared.opts, key)
-            search_pattern = sub_pattern.replace("[", "([").replace("]", "])")
+def get_all_batch_params(p: Union[modules.processing.StableDiffusionProcessingTxt2Img, modules.processing.StableDiffusionProcessingImg2Img], checkpoints_as_string: str, prompts_as_string: str, cycle_prompts: bool, enable_iterators: bool) -> List[BatchParams]:
 
-            if not re.search(r"\[0-9\]\+|\\d\+", sub_pattern):
-                raise RuntimeError(f'Can\'t find a number with the regex for {key}: "{sub_pattern}"')
-            
-            return search_pattern, sub_pattern
-
+        logger = Logger()
+        logger.debug = False
         utils = Utils()
 
         def get_batch_count_from_prompt(prompt: str) -> Tuple[int, str]:
             # extracts the batch count from the prompt if specified
-            search_pattern, sub_pattern = getRegexFromOpts("batchCountRegex")
-            number_match = re.search(search_pattern, prompt)
+            number_match = re.search(r"\{\{count:([0-9]+)\}\}", prompt)
             if number_match and number_match.group(1):
                 # Extract the number from the match object
                 number = int(number_match.group(1))  # Use group(1) to get the number inside parentheses
                 number = p.n_iter if number < 1 else number
-                prompt = re.sub(sub_pattern, '', prompt)
+                prompt = re.sub(r"\{\{count:[0-9]+\}\}", '', prompt)
             else:
                 number = p.n_iter
 
@@ -57,22 +50,20 @@ def get_all_batch_params(p: Union[modules.processing.StableDiffusionProcessingTx
         
         def get_clip_skip_from_prompt(prompt: str) -> Tuple[int, str]:
             # extracts the clip skip from the prompt if specified
-            search_pattern, sub_pattern = getRegexFromOpts("clipSkipRegex")
-            number_match = re.search(search_pattern, prompt)
+            number_match = re.search(r"\{\{clip_skip:([0-9]+)\}\}", prompt)
             if number_match and number_match.group(1):
                 # Extract the number from the match object
                 number = int(number_match.group(1))
                 number = shared.opts.data["CLIP_stop_at_last_layers"] if number < 1 else number
                 prompt = (
-                    re.sub(sub_pattern, '', prompt))
+                    re.sub(r"\{\{clip_skip:[0-9]+\}\}", '', prompt))
             else:
                 number = shared.opts.data["CLIP_stop_at_last_layers"]
-
 
             return number, prompt
 
         def split_postive_and_negative_postive_prompt(prompt: str) -> Tuple[str, str]:
-            pattern = getattr(shared.opts, "negPromptRegex")
+            pattern = r'{{neg:(.*?)}}'
             # Split the input string into parts
             parts = re.split(pattern, prompt)
             if len(parts) > 1:
@@ -93,13 +84,29 @@ def get_all_batch_params(p: Union[modules.processing.StableDiffusionProcessingTx
         prompts: List[str] = utils.remove_index_from_string(prompts_as_string).split(";")
         prompts = [prompt.replace('\n', '').strip() for prompt in prompts if not prompt.isspace() and prompt != '']
 
-        if len(prompts) != len(checkpoints):
-            logger.debug_log(f"len prompt: {len(prompts)}, len checkpoints{len(checkpoints)}")
-            raise RuntimeError(f"amount of prompts don't match with amount of checkpoints")
+        if cycle_prompts:
+            # Prepare an infinite iterator from the prompts list
+            infinite_prompts_iterator: Iterator = itertools.cycle(prompts)
+
+            # convert the infinite iterator to a checkpoint-length iterator
+            checkpoint_length_prompts_iterator: Iterator = itertools.islice(infinite_prompts_iterator, len(checkpoints))
+
+            # convert the checkpoint-length iterator to a list of prompts that matches the list of checkpoints in length 
+            prompts: List[str] = list(checkpoint_length_prompts_iterator)
+            # Now single prompt will be used for all checkpoints, and a shorter prompt list will just loop through as needed.
+            # If the prompt list is longer, the extra prompts will be ignored.
+        else:
+            if len(prompts) != len(checkpoints):
+                logger.debug_log(f"len prompt: {len(prompts)}, len checkpoints{len(checkpoints)}")
+                raise RuntimeError(f"amount of prompts don't match with amount of checkpoints")
+
 
         if len(prompts) == 0:
             raise RuntimeError(f"can't run without a checkpoint and prompt")
         
+        if enable_iterators:
+            process_variables_from_prompts(prompts)
+
         
         for i in range(len(checkpoints)):
 
@@ -113,12 +120,240 @@ def get_all_batch_params(p: Union[modules.processing.StableDiffusionProcessingTx
             prompt, neg_prompt = split_postive_and_negative_postive_prompt(prompts[i])
 
 
-            prompt = prompt.replace(getattr(shared.opts, "promptRegex"), p.prompt)
+            prompt = prompt.replace("{prompt}", p.prompt)
             neg_prompt = neg_prompt = p.negative_prompt + neg_prompt
 
 
             all_batch_params.append(BatchParams(checkpoints[i], prompt, neg_prompt, batch_count, clip_skip))
 
-            logger.debug_log(f"batch_params: {all_batch_params[i]}", False)
-
         return all_batch_params
+
+
+
+
+
+############################# Code To Process Prompt Operands/Iterators #############################
+
+
+
+
+# I could have been less verbose here, but
+#     I didn't want to push the case sensitivity logic
+#     into another function
+
+# TO ADD TO THIS LIST, ADD AN ENTRY TO THE OPERATORS DICTIONARY
+#   EXTERNAL FUNCTIONS ARE JUST NEEDED IF YOU WANT TO COVER DIFFERENT CASES OR SYNONYMS
+#   YOU CANNOT INCLUDE COMMAS IN THE OPERATOR STRINGS
+#   CURRENTLY LAMBDAS ARE LIMITED TO ONE VARIABLE BY THE CALLING CODE
+#      THAT DOESN'T MEAN YOU CAN'T ADD THEM HERE, BUT YOU'LL NEED TO EXPAND THE CALLING CODE
+
+# Define the operations
+
+sine = lambda x, amplitude=1, frequency=1 : amplitude * math.sin(frequency * x)
+cosine = lambda x, amplitude=1, frequency=1 : amplitude * math.cos(frequency * x)
+tangent = lambda x, amplitude=1, frequency=1 : amplitude * math.tan(frequency * x)
+arcsine = lambda x, amplitude=1, frequency=1 : amplitude * math.asin(frequency * x)
+arccosine = lambda x, amplitude=1, frequency=1 : amplitude * math.acos(frequency * x)
+arctangent = lambda x, amplitude=1, frequency=1 : amplitude * math.atan(frequency * x)
+square_root = lambda x: math.sqrt(x)
+log = lambda x, amplitude=1, frequency=1 : amplitude * math.log(frequency * x)
+log10 = lambda x, amplitude=1, frequency=1 : amplitude * math.log10(frequency * x)
+log2 = lambda x, amplitude=1, frequency=1 : amplitude * math.log2(frequency * x)
+approach_limit = lambda x, limit=1, rate=1: x + (limit - x) * 0.5 * rate
+
+Operators = {
+   # ADD NEW OPERATORS HERE
+   #'operator': operator_function,
+    'default': lambda x: x,
+    '++': lambda x: x + 1,
+    '--': lambda x: x - 1,
+    '+=': lambda x, n: x + n,
+    '-=': lambda x, n: x - n,
+    '*=': lambda x, n: x * n,
+    '/=': lambda x, n: x / n,
+    '%=': lambda x, n: x % n,
+    '^=': lambda x, n: x ** n,
+    'sin': sine,
+    'Sin': sine,
+    'SIN': sine,
+    'cos': cosine,
+    'Cos': cosine,
+    'COS': cosine,
+    'tan': tangent,
+    'Tan': tangent,
+    'TAN': tangent,
+    'asin': arcsine,
+    'Asin': arcsine,
+    'ASIN': arcsine,
+    'acos': arccosine,
+    'Acos': arccosine,
+    'ACOS': arccosine,
+    'atan': arctangent,
+    'Atan': arctangent,
+    'ATAN': arctangent,
+    'sqrt': square_root,
+    'Sqrt': square_root,
+    'SQRT': square_root,
+    'log': log,
+    'Log': log,
+    'LOG': log,
+    'log10': log10,
+    'Log10': log10,
+    'LOG10': log10,
+    'log2': log2,
+    'Log2': log2,
+    'LOG2': log2,
+    'approach_limit': approach_limit,
+    'Approach_Limit': approach_limit,
+    'APPROACH_LIMIT': approach_limit
+}
+
+
+
+
+
+import math
+import inspect
+
+# Define the pattern for the operation string 
+#     [initial value,promptIteratorName,function,optional n value, optional a value, optional b value, optional c value, optional d value, optional...]
+#     example: [0,varName,+=,10] translates into 0 as the first value, then 10, then 20, etc.
+#     see OperandFunctionDefinitions.py for the list of included functions
+
+def round_to_significant_digits(num, sig_figs):
+    try:
+        num = float(num)
+        if num != 0:
+            return round(num, sig_figs - int(math.floor(math.log10(abs(num)))) - 1)
+        else:
+            return 0  # Can't take the log of 0
+    except ValueError:
+        return num
+
+    
+    
+RGX_ITERATOR_PATTERN = '\[[^,\[\]]+(?:,[^,\[\]]+)*\]'
+
+def parse_operation_str(operation_str):
+    def is_valid_string(variable):
+        pattern = r'^[a-zA-Z0-9_-]+$'
+        return bool(re.match(pattern, variable))
+
+    def is_valid_operand_characters(variable):
+        pattern = r'[^,\s]+$'
+        return bool(re.match(pattern, variable))
+    
+    operation_match = re.match(RGX_ITERATOR_PATTERN, operation_str)
+
+    if operation_match is None:
+        return operation_str
+    
+    #remove the brackets
+    operation_match = operation_match.group()[1:-1]
+
+    #remove any trailing whitespace or commas
+    while operation_match and (operation_match[-1] == ',' or operation_match[-1] == ' '):
+        operation_match = operation_match[:-1]
+
+
+    #split and strip the string into its components
+    operation_arguments = operation_match.split(',')
+    operation_arguments = [arg.strip() for arg in operation_arguments]
+    
+    try:
+        initial_value = float(operation_arguments[0])
+    except ValueError:
+        return operation_str
+    
+    variable_name = operation_arguments[1]
+    if is_valid_string(variable_name) is False:
+        return operation_str
+    
+    operator = operation_arguments[2]
+    if is_valid_operand_characters(operator) is False:
+        return operation_str
+    
+    operands = []
+    #assign remaining arguments to operands, escape at the first invalid operand
+    for operand in operation_arguments[3:]:
+        try:
+            floatOperand = float(operand)
+            operands.append(floatOperand)
+        except ValueError:
+            break
+
+    #if operands is of type collection, but is empty, set it to None
+    if isinstance(operands, list) and len(operands) == 0:
+        operands = None
+
+    return initial_value, variable_name, operator, operands
+    
+def run_lambda_despite_too_many_args(lambda_function, args):
+    passed_args = args
+    
+    lambda_function_arg_count = len(inspect.getfullargspec(lambda_function).args)
+    #trim the arg length
+    passed_args = passed_args[:lambda_function_arg_count]
+    
+    #while last passed ark is None, trim it
+    while passed_args and passed_args[-1] is None:
+        passed_args = passed_args[:-1]
+
+    #run round_to_significant_digits for each item in passed args
+    passed_args = [round_to_significant_digits(arg, 5) for arg in passed_args]
+
+    try:
+        lambda_result = lambda_function(*passed_args)
+        return round_to_significant_digits(lambda_result, 12)
+    except TypeError:
+        print(f"Lambda or rounding function encountered a TypeError. Lambda result: {lambda_result}, args: {args}")
+        return args[0]
+    
+def process_variables_from_prompts(prompts):
+    #dictionary format is {variable_name: (initial/iterating value, operator, operands)}
+    variables_dict = {}
+    processed_prompts = []
+    for prompt in prompts:
+        matches = re.findall(RGX_ITERATOR_PATTERN, prompt)
+        for match in matches:
+            operation_str = match
+
+            parsed_operation_args = parse_operation_str(operation_str)
+
+            # If parsed_operation is a string, do nothing
+            if isinstance(parsed_operation_args, str):
+                print(f"parse_operation_str returned a string, leaving unchanged: {parsed_operation_args}")                
+                continue
+           
+            parsed_iterator_value, parsed_var_name, parsed_operator, parsed_operands = parsed_operation_args
+            print(f"parsed from custom iterator: {parsed_iterator_value} {parsed_var_name} {parsed_operator} {str(parsed_operands)}")
+            if parsed_var_name in variables_dict:
+                #parsed operator and operands can change, but initial value is ignored after first detection
+                if parsed_operator in Operators:
+                    operation_lambda = Operators[parsed_operator]
+                else:
+                    print(f"[{parsed_operator} not found in operators, returning initial value: {parsed_iterator_value}")
+                    prompt = prompt.replace(match,str(parsed_iterator_value).rstrip('0').rstrip('.'), 1)
+                    continue
+                stored_iterator_value = variables_dict[parsed_var_name][0]
+                try:
+                    stored_iterator_value = float(stored_iterator_value)
+                except ValueError:
+                    print(f"stored_iterator_value: {stored_iterator_value} is not a float, returning initial value: {parsed_iterator_value}")
+                    prompt = prompt.replace(match,str(parsed_iterator_value).rstrip('0').rstrip('.'), 1)
+                    continue
+                lambda_args = [stored_iterator_value, *(parsed_operands if parsed_operands is not None else [])]
+
+                parsed_iterator_value = run_lambda_despite_too_many_args(operation_lambda, lambda_args)
+            
+            #remove any trailing zeros or decimals
+            parsed_iterator_value = str(parsed_iterator_value).rstrip('0').rstrip('.')
+            #if variable is not in the dictionary, add it but it doesn't get processed the first time it's encountered
+            variables_dict[parsed_var_name] = [parsed_iterator_value, parsed_operator, parsed_operands]
+          
+            prompt = prompt.replace(match,str(variables_dict[parsed_var_name][0]), 1)
+            print(f"New prompt after iterator applied: {prompt}")
+            
+        processed_prompts.append(prompt)
+
+    return processed_prompts

--- a/scripts/batchCheckpointsPrompt.py
+++ b/scripts/batchCheckpointsPrompt.py
@@ -142,6 +142,38 @@ class CheckpointLoopScript(scripts.Script):
                 """)
                 add_model_version_checkbox = gr.inputs.Checkbox(label="Add model version to checkpoint names")
 
+                cycle_prompts_checkbox = gr.inputs.Checkbox(
+                    label="Loop Through Prompts")
+                gr.Markdown("""
+                    Prompt list will be cycled through if shorter than model list.<br>
+                    A single prompt will repeat. <br>
+                    A longer prompt list will have the extra prompts ignored.
+                """)
+                
+                enable_iterators_checkbox = gr.inputs.Checkbox(
+                    label="Enable Process Iterators")
+                gr.Markdown("""
+                    Process Iterators: use the pattern [initVal,iteratorLabel,operator,operand,operand,operand...]. The brackets and contents will be replaced by the result of the operator. The initial value will be used first, and any subsequent call to the same iterator label will apply the operator using it's optional operands.<br>
+                    <br>
+                        Example:  (close up:[0.2,iterator1,+=,0.1])   -this will start at 0.2 and increase by 0.1 every time this iterator 'iterator1' is encountered - if it's a single prompt, it will be increased every generation.  Functions available: <br>
+                    <br>
+                    ++,--,sqrt:<br>
+                    [startInt,myIteratorName,++]<br>
+                    [1,myIncrementor,++] (put after a lora/lyco training checkpoint...)<br>
+                    <br>
+                    +=,-=,*=,/=,%=,^=:<br>
+                    [startInt,myAdderName,+=,operandFloat(default=1)]<br>
+                    [0.3,myMultiplier,*=,1.1]  (this will increase slowly but faster as it goes)<br>
+                    <br>
+                    log,log10,log2:<br>
+                    [startInt,myIteratorName,sqrt,amplitudeFloat(default=1),FrequencyFloat(default=1)] <br>
+                    [0.5,mySinIterator,sin,0.1(default=1),FrequencyFloat(default=1)] 
+                    <br>
+                    approach_limit:<br>
+                    [startInt,myIteratorName,approach_limit,limitFloat(default=1),RateFloat(default=1)]
+                """)
+                process_iterators_text_field = gr.Textbox(label="", interactive=False)
+
             # Actions
 
             fill_checkpoints_button.click(
@@ -159,7 +191,9 @@ class CheckpointLoopScript(scripts.Script):
 
         with gr.Tab("help"):
             gr.Markdown(self.utils.get_help_md())
-        return [checkpoints_input, checkpoints_prompt, margin_size]
+        #return [checkpoints_input, checkpoints_prompt, margin_size]
+        return [checkpoints_input, checkpoints_prompt, margin_size, cycle_prompts_checkbox, enable_iterators_checkbox]
+
 
     def show(self, is_img2img) -> bool:
         self.is_img2_img = is_img2img
@@ -213,7 +247,7 @@ class CheckpointLoopScript(scripts.Script):
         return all_infotexts
 
 
-    def run(self, p: Union[modules.processing.StableDiffusionProcessingTxt2Img, modules.processing.StableDiffusionProcessingImg2Img], checkpoints_text, checkpoints_prompt, margin_size) -> modules.processing.Processed:
+    def run(self, p: Union[modules.processing.StableDiffusionProcessingTxt2Img, modules.processing.StableDiffusionProcessingImg2Img], checkpoints_text, checkpoints_prompt, margin_size, cycle_prompts_checkbox, enable_iterators_checkbox) -> modules.processing.Processed:
 
         image_processed = []
         self.margin_size = margin_size
@@ -226,7 +260,7 @@ class CheckpointLoopScript(scripts.Script):
         
         self.base_prompt: str = p.prompt
 
-        all_batchParams = get_all_batch_params(p, checkpoints_text, checkpoints_prompt)
+        all_batchParams = get_all_batch_params(p, checkpoints_text, checkpoints_prompt, cycle_prompts_checkbox,enable_iterators_checkbox)
 
         total_batch_count = get_total_batch_count(all_batchParams)
         total_steps = p.steps * total_batch_count

--- a/scripts/batchCheckpointsPrompt.py
+++ b/scripts/batchCheckpointsPrompt.py
@@ -155,7 +155,7 @@ class CheckpointLoopScript(scripts.Script):
                 gr.Markdown("""
                     Process Iterators: use the pattern [initVal,iteratorLabel,operator,operand,operand,operand...]. The brackets and contents will be replaced by the result of the operator. The initial value will be used first, and any subsequent call to the same iterator label will apply the operator using it's optional operands.<br>
                     <br>
-                        Example:  (close up:[0.2,iterator1,+=,0.1])   -this will start at 0.2 and increase by 0.1 every time this iterator 'iterator1' is encountered - if it's a single prompt, it will be increased every generation.  Functions available: <br>
+                    Example:  (close up:[0.2,iterator1,+=,0.1])   -this will start at 0.2 and increase by 0.1 every time this iterator 'iterator1' is encountered - if it's a single prompt, it will be increased every generation.  Functions available: <br>
                     <br>
                     ++,--,sqrt:<br>
                     [startInt,myIteratorName,++]<br>


### PR DESCRIPTION
Added a checkbox to advanced toloop through prompts if prompt list is shorter than model list. Can repeat a single prompt.

Added a checkbox and info to advanced to enable embedding custom iterators in the prompts that change with each image generation that has that prompt name. See details below.



Loop Through Prompts
Prompt list will be cycled through if shorter than model list.
A single prompt will repeat.
A longer prompt list will have the extra prompts ignored.

Enable Process Iterators
Process Iterators: use the pattern [initVal,iteratorLabel,operator,operand,operand,operand…]. The brackets and contents will be replaced by the result of the operator. The initial value will be used first, and any subsequent call to the same iterator label will apply the operator using it’s optional operands.

Example: (close up:[0.2,iterator1,+=,0.1]) -this will start at 0.2 and increase by 0.1 every time this iterator ‘iterator1’ is encountered - if it’s a single prompt, it will be increased every generation. Functions available:

++,–,sqrt:
[startInt,myIteratorName,++]
[1,myIncrementor,++] (put after a lora/lyco training checkpoint…)

+=,-=,=,/=,%=,^=:
[startInt,myAdderName,+=,operandFloat(default=1)]
[0.3,myMultiplier,=,1.1] (this will increase slowly but faster as it goes)

log,log10,log2:
[startInt,myIteratorName,sqrt,amplitudeFloat(default=1),FrequencyFloat(default=1)]
[0.5,mySinIterator,sin,0.1(default=1),FrequencyFloat(default=1)]
approach_limit:
[startInt,myIteratorName,approach_limit,limitFloat(default=1),RateFloat(default=1)]